### PR TITLE
#129 Improve URL format

### DIFF
--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -200,6 +200,7 @@ let CONFIG = {
 			'/src/webserver/private/js/class/AbstractStructureMap.js',
 			'/src/webserver/private/js/class/StructureMap.js',
 			'/src/webserver/private/js/class/BrowserMap.js',
+			'/src/webserver/private/js/class/UrlManager.js',
 			'/src/webserver/private/js/class/VibrateApi.js',
 			// modules
 			'/src/webserver/private/js/modules/cookie.js',

--- a/src/webserver/pages/api/password.js
+++ b/src/webserver/pages/api/password.js
@@ -1,6 +1,7 @@
 const pathCustom = require(BASE_DIR_GET('/src/libs/path.js'));
 const LOG = require(BASE_DIR_GET('/src/libs/log.js'));
 const perms = require(BASE_DIR_GET('/src/libs/permissions.js'));
+const UrlManager = require("../../private/js/class/UrlManager");
 
 module.exports = function (webserver, endpoint) {
 
@@ -63,14 +64,14 @@ module.exports = function (webserver, endpoint) {
 				}, 'Password "' + req.query.password + '" is valid.').end(200);
 				return;
 			}
-			// automatic redirect to the folder
-			let redirectFolder = passwordObject.getPermissions()[0];
-			if (redirectFolder.slice(-1) !== '/') {
+
+			let redirectTarget = passwordObject.getPermissions()[0];
+			if (redirectTarget.endsWith('/')) {
 				// this is not folder, redirect to dirname of this path
-				redirectFolder = pathCustom.dirname(redirectFolder);
+				res.redirect((new UrlManager().setPath(redirectTarget)));
+			} else {
+				res.redirect((new UrlManager().setFile(redirectTarget)));
 			}
-			res.cookie('pmg-redirect', redirectFolder, {expires: new Date(253402300000000)});
-			res.redirect('/');
 		} catch (error) {
 			res.result.setError('Error while checking password: ' + error.message).end(500);
 		}

--- a/src/webserver/private/js/class/Item.js
+++ b/src/webserver/private/js/class/Item.js
@@ -19,7 +19,6 @@ class Item {
 		Object.assign(this, item);
 		this.index = index;
 
-		this.url = pathToUrl(this.path);
 		this.paths = this.path.split('/').filter(n => n); // split path to folders and remove empty elements (if path start or end with /)
 		this.created = this.created ? new Date(this.created) : null;
 
@@ -30,7 +29,6 @@ class Item {
 		folders.pop();
 		this.folder = folders.join('/') + '/';
 
-		this.urls = this.paths.map(pathToUrl); // split path to folders and remove empty elements (if path start or end with /)
 		if (!this.text) { // do not override if set by server
 			if (this.isRoot()) {
 				this.text = this.path;

--- a/src/webserver/private/js/class/MediaPopup.js
+++ b/src/webserver/private/js/class/MediaPopup.js
@@ -127,7 +127,6 @@ class MediaPopup extends EventTarget {
 		let openUrl = fileItem.getFileUrl(false);
 		let openUrlFull = fileItem.getFileUrl(false, false);
 		const downloadUrl = fileItem.getFileUrl(true);
-		const shareUrl = window.location.origin + '/#' + fileItem.url;
 
 		// Canvas data
 		if (openUrl === null) { // If item has no view url, use icon to indicate it is file that has to be downloaded
@@ -144,7 +143,7 @@ class MediaPopup extends EventTarget {
 		// @TODO fill and open media canvas (which is not in popup itself)
 		$('#popup-media-details-download').attr('href', downloadUrl);
 		$('#popup-media-details-open-full').attr('href', openUrlFull);
-		$('#popup-media-details-share').attr('href', shareUrl);
+		$('#popup-media-details-share').attr('href', urlManager.withFile(fileItem.path));
 
 		function setMediaSrc(type, src) {
 			const element = (type === 'audio')
@@ -189,24 +188,24 @@ class MediaPopup extends EventTarget {
 		}
 
 		// generate URL for previous file buttons
-		let prevFileUrl = fileItem.url; // default is current file (do nothing)
+		const previousItemUrlManager = urlManager.withFile(fileItem.path); // default is current file (do nothing)
 		if (previousFileItem && previousFileItem.isFile) { // if there is some previous file
-			prevFileUrl = previousFileItem.url;
+			previousItemUrlManager.setFile(previousFileItem.path);
 			this.elementPrev.dataset.index = previousFileItem.index;
 		} else {
 			this.elementPrev.dataset.index = '';
 		}
-		this.elementPrev.setAttribute('href', '#' + prevFileUrl);
+		this.elementPrev.setAttribute('href', previousItemUrlManager.getUrl());
 
 		// generate URL for next file buttons
-		let nextFileUrl = fileItem.url; // default is current file (do nothing)
+		const nextItemUrlManager = urlManager.withFile(fileItem.path); // default is current file (do nothing)
 		if (nextFileItem && nextFileItem.isFile) { // if there is some next file
-			nextFileUrl = nextFileItem.url;
+			nextItemUrlManager.setFile(nextFileItem.path);
 			this.elementNext.dataset.index = nextFileItem.index;
 		} else {
 			this.elementNext.dataset.index = ''
 		}
-		this.elementNext.setAttribute('href', '#' + nextFileUrl);
+		this.elementNext.setAttribute('href', nextItemUrlManager.getUrl());
 
 		this.element.style.display = 'block';
 	}

--- a/src/webserver/private/js/class/Structure.js
+++ b/src/webserver/private/js/class/Structure.js
@@ -84,8 +84,6 @@ class Structure extends EventTarget {
 				},
 			}));
 		}
-
-		Settings.save('hashBeforeUnload', path)
 	}
 
 	/**
@@ -394,7 +392,21 @@ class Structure extends EventTarget {
 			}
 		}, this);
 		return result;
+	}
 
+	/**
+	 * Get item by path
+	 *
+	 * @param {string} path
+	 * @returns {Item|null}
+	 */
+	getByPath(path) {
+		for (const item of this.items) {
+			if (path === item.path) {
+				return item;
+			}
+		}
+		return null;
 	}
 
 	showSearchActions(showRoot, showSubdirectory) {

--- a/src/webserver/private/js/class/UrlManager.js
+++ b/src/webserver/private/js/class/UrlManager.js
@@ -1,0 +1,106 @@
+class UrlManager extends EventTarget {
+	/**
+	 * @param {string?} queryRaw Provide raw query, for example from `window.location.search` variable in format
+	 * `?param1=value1&param2=value2`
+	 */
+	constructor(queryRaw = null) {
+		super();
+
+		this._setRawQueryInternal(queryRaw);
+	}
+
+	setRawQuery(queryRaw) {
+		this._setRawQueryInternal(queryRaw);
+		this._triggerEvent();
+		return this;
+	}
+
+	_setRawQueryInternal(queryRaw) {
+		const query = new URLSearchParams(queryRaw);
+		this.path = query.get('path') ?? null;
+		this.file = query.get('file') ?? null;
+
+		// Shorter URL to open file. Path (directory) is extracted from file parameter.
+		// For example, these two URLs are the same:
+		// - '/?path=/some/directory/&file=/some/directory/some-file.jpeg'
+		// - '/?file=/some/directory/some-file.jpeg'
+		if (this.path === null && this.file !== null) {
+			const paths = this.file.split('/');
+			paths.pop();
+			this.path = paths.join('/') + '/';
+		}
+
+		return this;
+	}
+
+	setPath(path) {
+		this.path = path;
+		this._triggerEvent();
+		return this;
+	}
+
+	withPath(path) {
+		return (new UrlManager())
+			.setPath(path)
+			.setFile(this.file);
+	}
+
+	setFile(filePath) {
+		this.file = filePath;
+		this._triggerEvent();
+		return this;
+	}
+
+	withFile(filePath) {
+		return (new UrlManager())
+			.setPath(this.path)
+			.setFile(filePath);
+	}
+
+	/**
+	 * Build URL from stored parameters and returns string.
+	 *
+	 * @return {string}
+	 */
+	getUrl() {
+		const query = new URLSearchParams();
+		if (this.path !== null) {
+			query.set('path', this.path);
+		}
+		if (this.file !== null) {
+			query.set('file', this.file);
+		}
+
+		let result = '/';
+		let queryString = query.toString();
+		if (queryString !== '') {
+			queryString = queryString
+				.replaceAll('%2F', '/')
+				.replaceAll('%28', '(')
+				.replaceAll('%29', ')');
+			result += '?' + queryString;
+		}
+
+		return result;
+	}
+
+	/**
+	 * @return {string}
+	 */
+	toString() {
+		return this.getUrl();
+	}
+
+	_triggerEvent() {
+		const url = this.getUrl();
+		this.dispatchEvent(new CustomEvent('statechange', {
+			detail: {
+				url: url,
+			},
+		}));
+	}
+}
+
+if (typeof module !== 'undefined') { // Add support for node.js
+	module.exports = UrlManager;
+}

--- a/src/webserver/private/js/functions.js
+++ b/src/webserver/private/js/functions.js
@@ -439,36 +439,6 @@ function numberRound(number, points) {
 global.numberRound = numberRound;
 
 /**
- * Generate nice URL without URL decoding
- *
- * /demo/folder with+spaces and+plus signs/
- * ->
- * /demo/folder+with\+spaces+and\+plus+signs/
- */
-function pathToUrl(path) {
-	path = path.replace(/\+/g, '\\+');
-	return path.replaceAll(' ', '+');
-}
-
-global.pathToUrl = pathToUrl;
-
-/**
- * Get path from nice URL
- *
- * /demo/folder+with\+spaces+and\+plus+signs/
- * ->
- * /demo/folder with+spaces and+plus signs/
- */
-function pathFromUrl(path) {
-	// replace spaces (need to check, if + is not escaped)
-	path = path.replace(/([^\\])\+/g, '$1 ');
-	// remove escaping \\+ to get +
-	return path.replaceAll('\\+', '+');
-}
-
-global.pathFromUrl = pathFromUrl;
-
-/**
  * Copy text into clipboard.
  *
  * @author https://www.w3schools.com/howto/howto_js_copy_clipboard.asp

--- a/src/webserver/private/js/modules/settings.js
+++ b/src/webserver/private/js/modules/settings.js
@@ -17,7 +17,6 @@
 		 * @link https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate
 		 */
 		vibrationError: [100, 200, 100, 200, 100],
-		hashBeforeUnload: '/',
 		presentationEnabled: false,
 		compress: true,
 		structureDisplayType: 'rows',


### PR DESCRIPTION
- rewritten page to store current page state into query parameters instead of hash part of URL
- added new UrlManager.js which manages all changes and generates all shareable URLs
- automatically convert old URLs with hash into new format
- updated code to use `UrlManager` instead of `item.url`
- removed restoring URL from last known state if currently loaded URL does not contain any parameters (confusing for users), removed `hashBeforeUnload` settings key
- redirecting from server is now done to direct URL instead of storing it into cookie `pmg-redirect`
- added `Structure.getByPath()`
- cleanup: removed unused `item.url`, `item.urls`, `pathToUrl()`, `pathFromURl()`
- smaller refactoring and code style improvements